### PR TITLE
feat: added view data to `ViewManager`

### DIFF
--- a/src/Controller/Core/BasicView.h
+++ b/src/Controller/Core/BasicView.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <Controller/Core/AccountManager.h>
 #include <Controller/Core/GlobalAgent.hh>
+#include <Controller/Core/MessageManager.h>
 #include <Controller/Core/UiBase.h>
+#include <Controller/Core/ViewManager.h>
 
 EVENTO_UI_START
 

--- a/src/Controller/Core/MessageManager.h
+++ b/src/Controller/Core/MessageManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Controller/Core/BasicView.h>
 #include <Controller/Core/GlobalAgent.hh>
 #include <Controller/Core/UiBase.h>
 #include <chrono>
@@ -8,7 +7,7 @@
 
 EVENTO_UI_START
 
-class MessageManager : GlobalAgent<MessageManagerBridge> {
+class MessageManager : private GlobalAgent<MessageManagerBridge> {
     friend class UiBridge;
     UiBridge& bridge;
     std::string logOrigin = "MessageManager";

--- a/src/Controller/Core/ViewManager.h
+++ b/src/Controller/Core/ViewManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Controller/Core/BasicView.h>
 #include <Controller/Core/GlobalAgent.hh>
 #include <Controller/Core/UiBase.h>
 #include <set>

--- a/src/Controller/UiBridge.cc
+++ b/src/Controller/UiBridge.cc
@@ -95,6 +95,7 @@ bool UiBridge::inEventLoop() const {
 }
 
 void UiBridge::call(Action& action) {
+    slint::private_api::assert_main_thread();
     std::for_each(views.begin(),
                   views.end(),
                   [&action](const std::pair<const ViewName, std::shared_ptr<BasicView>>& view) {
@@ -103,6 +104,7 @@ void UiBridge::call(Action& action) {
 }
 
 void UiBridge::call(Action& action, ViewName target) {
+    slint::private_api::assert_main_thread();
     action(*views.at(target));
 }
 


### PR DESCRIPTION
导航到新页面时，可以提供数据：

- 在各 navigate 函数添加第二参数，默认为空，仅限 Controller 接口可用
- 数据会与页面栈的页面一一对应地存储，出栈时会销毁页面对应的数据
- 需要自定义数据类型，继承 `ViewData`
- 使用 `bridge.getViewManager().getData()` 获取当前的数据，需要自己进行类型转换

---

判断 `shared_ptr` 为空：https://en.cppreference.com/w/cpp/memory/shared_ptr/operator_bool