### PR TITLE
feat(net): evento api

### DIFF
--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -75,18 +75,8 @@ Task<Result<void>> NetworkClient::refreshAccessToken(std::string const& refreshT
     co_return Ok();
 }
 
-Task<Result<EventEntityList>> NetworkClient::getActiveEventList(int& current,
-                                                                int& total,
-                                                                int page,
-                                                                int size) {
-    std::initializer_list<urls::param> params;
-    if (page == -1) {
-        params = {{"active", "true"}};
-    } else {
-        params = {{"page", std::to_string(page)},
-                  {"size", std::to_string(size)},
-                  {"active", "true"}};
-    }
+Task<Result<EventEntityList>> NetworkClient::getActiveEventList() {
+    std::initializer_list<urls::param> params = {{"active", "true"}};
 
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query", params));
@@ -95,9 +85,7 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -105,16 +93,8 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(int& current,
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getLatestEventList(int& current,
-                                                                int& total,
-                                                                int page,
-                                                                int size) {
-    std::initializer_list<urls::param> params;
-    if (page == -1) {
-        params = {{"start", "now"}};
-    } else {
-        params = {{"page", std::to_string(page)}, {"size", std::to_string(size)}, {"start", "now"}};
-    }
+Task<Result<EventEntityList>> NetworkClient::getLatestEventList() {
+    std::initializer_list<urls::param> params = {{"start", "now"}};
 
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query", params));
@@ -123,9 +103,7 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -133,10 +111,7 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(int& current,
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int& current,
-                                                                 int& total,
-                                                                 int page,
-                                                                 int size) {
+Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int size) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
                                                                {{"page", std::to_string(page)},
@@ -147,9 +122,7 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -157,13 +130,10 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int& current,
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getActiveEventList(
-    std::string const& Department, int& current, int& total, int page, int size) {
+Task<Result<EventEntityList>> NetworkClient::getActiveEventList(std::string const& Department) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
-                                                               {{"page", std::to_string(page)},
-                                                                {"size", std::to_string(size)},
-                                                                {"active", "true"},
+                                                               {{"active", "true"},
                                                                 {"larkDepartmentName",
                                                                  Department}}));
     if (result.isErr())
@@ -171,9 +141,7 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -181,13 +149,10 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getLatestEventList(
-    std::string const& Department, int& current, int& total, int page, int size) {
+Task<Result<EventEntityList>> NetworkClient::getLatestEventList(std::string const& Department) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
-                                                               {{"page", std::to_string(page)},
-                                                                {"size", std::to_string(size)},
-                                                                {"start", "now"},
+                                                               {{"start", "now"},
                                                                 {"larkDepartmentName",
                                                                  Department}}));
     if (result.isErr())
@@ -195,9 +160,7 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -205,8 +168,9 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(
-    std::string const& Department, int& current, int& total, int page, int size) {
+Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(std::string const& Department,
+                                                                 int page,
+                                                                 int size) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
                                                                {{"page", std::to_string(page)},
@@ -219,9 +183,7 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["elements"].get<EventEntityList>();
-        current = result.unwrap()["current"].get<int>();
-        total = result.unwrap()["total"].get<int>();
+        nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -156,6 +156,72 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int& current,
 
     co_return Ok(entity);
 }
+
+Task<Result<EventEntityList>> NetworkClient::getActiveEventList(
+    std::string const& Department, int& current, int& total, int page, int size) {
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/query",
+                                                               {{"page", std::to_string(page)},
+                                                                {"size", std::to_string(size)},
+                                                                {"active", "true"},
+                                                                {"larkDepartmentName",
+                                                                 Department}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
+        current = result.unwrap()["data"]["current"].get<int>();
+        total = result.unwrap()["data"]["total"].get<int>();
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
+}
+
+Task<Result<EventEntityList>> NetworkClient::getLatestEventList(
+    std::string const& Department, int& current, int& total, int page, int size) {
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/query",
+                                                               {{"page", std::to_string(page)},
+                                                                {"size", std::to_string(size)},
+                                                                {"start", "now"},
+                                                                {"larkDepartmentName",
+                                                                 Department}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
+        current = result.unwrap()["data"]["current"].get<int>();
+        total = result.unwrap()["data"]["total"].get<int>();
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
+}
+
+Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(
+    std::string const& Department, int& current, int& total, int page, int size) {
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/query",
+                                                               {{"page", std::to_string(page)},
+                                                                {"size", std::to_string(size)},
+                                                                {"end", "now"},
+                                                                {"larkDepartmentName",
+                                                                 Department}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
+        current = result.unwrap()["data"]["current"].get<int>();
+        total = result.unwrap()["data"]["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -313,6 +379,22 @@ Task<Result<SlideEntityList>> NetworkClient::getEventSlide(int eventId) {
         co_return Err(result.unwrapErr());
 
     SlideEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
+}
+
+Task<Result<DepartmentInfoEntityList>> NetworkClient::getDepartmentInfo() {
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("v2/client/lark/department"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    DepartmentInfoEntityList entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -192,6 +192,22 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(std::string con
     co_return Ok(entity);
 }
 
+Task<Result<EventEntityList>> NetworkClient::getEventList(std::initializer_list<urls::param> params) {
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/query", params));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
+}
+
 Task<Result<AttachmentEntity>> NetworkClient::getAttachment(int eventId) {
     auto result = co_await this->request<api::Evento>(
         http::verb::get, endpoint(std::format("api/v2/client/event/{}/attachments", eventId)));

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -76,15 +76,14 @@ Task<Result<void>> NetworkClient::refreshAccessToken(std::string const& refreshT
     co_return Ok();
 }
 
-Task<Result<EventEntityList>> NetworkClient::getActiveEventList() {
-    std::initializer_list<urls::param> params = {{"active", "true"}};
-
+Task<Result<EventQueryRes>> NetworkClient::getActiveEventList() {
     auto result = co_await this->request<api::Evento>(http::verb::get,
-                                                      endpoint("/v2/client/event/query", params));
+                                                      endpoint("/v2/client/event/query",
+                                                               {{"active", "true"}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    EventEntityList entity;
+    EventQueryRes entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
@@ -94,15 +93,14 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList() {
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getLatestEventList() {
-    std::initializer_list<urls::param> params = {{"start", "now"}};
-
+Task<Result<EventQueryRes>> NetworkClient::getLatestEventList() {
     auto result = co_await this->request<api::Evento>(http::verb::get,
-                                                      endpoint("/v2/client/event/query", params));
+                                                      endpoint("/v2/client/event/query",
+                                                               {{"start", "now"}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    EventEntityList entity;
+    EventQueryRes entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
@@ -112,7 +110,7 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList() {
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int size) {
+Task<Result<EventQueryRes>> NetworkClient::getHistoryEventList(int page, int size) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
                                                                {{"page", std::to_string(page)},
@@ -121,7 +119,7 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int s
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    EventEntityList entity;
+    EventQueryRes entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
@@ -131,58 +129,19 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int s
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getActiveEventList(std::string const& Department) {
-    auto result = co_await this->request<api::Evento>(http::verb::get,
-                                                      endpoint("/v2/client/event/query",
-                                                               {{"active", "true"},
-                                                                {"larkDepartmentName",
-                                                                 Department}}));
-    if (result.isErr())
-        co_return Err(result.unwrapErr());
-
-    EventEntityList entity;
-    try {
-        nlohmann::from_json(result.unwrap(), entity);
-    } catch (const nlohmann::json::exception& e) {
-        co_return Err(Error(Error::JsonDes, e.what()));
-    }
-
-    co_return Ok(entity);
-}
-
-Task<Result<EventEntityList>> NetworkClient::getLatestEventList(std::string const& Department) {
-    auto result = co_await this->request<api::Evento>(http::verb::get,
-                                                      endpoint("/v2/client/event/query",
-                                                               {{"start", "now"},
-                                                                {"larkDepartmentName",
-                                                                 Department}}));
-    if (result.isErr())
-        co_return Err(result.unwrapErr());
-
-    EventEntityList entity;
-    try {
-        nlohmann::from_json(result.unwrap(), entity);
-    } catch (const nlohmann::json::exception& e) {
-        co_return Err(Error(Error::JsonDes, e.what()));
-    }
-
-    co_return Ok(entity);
-}
-
-Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(std::string const& Department,
-                                                                 int page,
-                                                                 int size) {
+Task<Result<EventQueryRes>> NetworkClient::getDepartmentEventList(std::string const& department,
+                                                                  int page,
+                                                                  int size) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query",
                                                                {{"page", std::to_string(page)},
                                                                 {"size", std::to_string(size)},
-                                                                {"end", "now"},
                                                                 {"larkDepartmentName",
-                                                                 Department}}));
+                                                                 department}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    EventEntityList entity;
+    EventQueryRes entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
@@ -192,13 +151,13 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(std::string con
     co_return Ok(entity);
 }
 
-Task<Result<EventEntityList>> NetworkClient::getEventList(std::initializer_list<urls::param> params) {
+Task<Result<EventQueryRes>> NetworkClient::getEventList(std::initializer_list<urls::param> params) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/query", params));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    EventEntityList entity;
+    EventQueryRes entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {
@@ -367,13 +326,13 @@ Task<Result<SlideEntityList>> NetworkClient::getEventSlide(int eventId) {
     co_return Ok(entity);
 }
 
-Task<Result<DepartmentInfoEntityList>> NetworkClient::getDepartmentInfo() {
+Task<Result<DepartmentEntityList>> NetworkClient::getDepartmentList() {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("v2/client/lark/department"));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    DepartmentInfoEntityList entity;
+    DepartmentEntityList entity;
     try {
         nlohmann::from_json(result.unwrap(), entity);
     } catch (const nlohmann::json::exception& e) {

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -5,6 +5,7 @@
 #include <boost/url/params_view.hpp>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace evento {
 
@@ -71,7 +72,7 @@ Task<Result<void>> NetworkClient::refreshAccessToken(std::string const& refreshT
         co_return Err(Error(Error::JsonDes, e.what()));
     }
 
-    co_return Ok(entity);
+    co_return Ok();
 }
 
 Task<Result<EventEntityList>> NetworkClient::getActiveEventList() {
@@ -109,7 +110,8 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList() {
 Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int size) {
     auto result = co_await this->request<api::Evento>(http::verb::get,
                                                       endpoint("/v2/client/event/history",
-                                                               {{"page", page}, {"size", size}}));
+                                                               {{"page", std::to_string(page)},
+                                                                {"size", std::to_string(size)}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
@@ -160,11 +162,10 @@ Task<Result<FeedbackEntity>> NetworkClient::getUserFeedback(int eventId) {
 Task<Result<void>> NetworkClient::addUserFeedback(int eventId,
                                                   int rating,
                                                   std::string const& content) {
-    auto result = co_await this
-                      ->request<api::Evento>(http::verb::post,
-                                             endpoint(std::format("/v2/client/event/{}/feedback",
-                                                                  eventId),
-                                                      {{"rating", rating}, {"content", content}}));
+    auto result = co_await this->request<api::Evento>(
+        http::verb::post,
+        endpoint(std::format("/v2/client/event/{}/feedback", eventId),
+                 {{"rating", std::to_string(rating)}, {"content", content}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
     FeedbackEntity entity;
@@ -174,7 +175,7 @@ Task<Result<void>> NetworkClient::addUserFeedback(int eventId,
         co_return Err(Error(Error::JsonDes, e.what()));
     }
 
-    co_return Ok(entity);
+    co_return Ok();
 }
 
 Task<Result<void>> NetworkClient::checkInEvent(int eventId, std::string const& code) {
@@ -188,11 +189,12 @@ Task<Result<void>> NetworkClient::checkInEvent(int eventId, std::string const& c
 }
 
 Task<Result<void>> NetworkClient::subscribeEvent(int eventId, bool subscribe) {
+    std::string subscribeStr = subscribe ? "true" : "false";
     auto result = co_await this
                       ->request<api::Evento>(http::verb::post,
                                              endpoint(std::format("/v2/client/event/{}/subscribe",
                                                                   eventId),
-                                                      {{"subscribe", subscribe}}));
+                                                      {{"subscribe", subscribeStr}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
@@ -201,11 +203,12 @@ Task<Result<void>> NetworkClient::subscribeEvent(int eventId, bool subscribe) {
 
 Task<Result<void>> NetworkClient::subscribeDepartment(std::string const& larkDepartment,
                                                       bool subscribe) {
+    std::string subscribeStr = subscribe ? "true" : "false";
     auto result = co_await this
                       ->request<api::Evento>(http::verb::post,
                                              endpoint(std::format("/v2/client/event/{}/subscribe",
                                                                   larkDepartment),
-                                                      {{"subscribe", subscribe}}));
+                                                      {{"subscribe", subscribeStr}}));
     if (result.isErr())
         co_return Err(result.unwrapErr());
 

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -66,7 +66,7 @@ Task<Result<void>> NetworkClient::refreshAccessToken(std::string const& refreshT
         co_return Err(result.unwrapErr());
 
     try {
-        this->tokenBytes = result.unwrap()["data"]["accessToken"].get<std::string>();
+        this->tokenBytes = result.unwrap()["accessToken"].get<std::string>();
     } catch (const nlohmann::json::exception& e) {
         this->tokenBytes = std::nullopt;
         co_return Err(Error(Error::JsonDes, e.what()));
@@ -95,9 +95,9 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -123,9 +123,9 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -147,9 +147,9 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int& current,
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -171,9 +171,9 @@ Task<Result<EventEntityList>> NetworkClient::getActiveEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -195,9 +195,9 @@ Task<Result<EventEntityList>> NetworkClient::getLatestEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }
@@ -219,9 +219,9 @@ Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(
 
     EventEntityList entity;
     try {
-        entity = result.unwrap()["data"]["elements"].get<EventEntityList>();
-        current = result.unwrap()["data"]["current"].get<int>();
-        total = result.unwrap()["data"]["total"].get<int>();
+        entity = result.unwrap()["elements"].get<EventEntityList>();
+        current = result.unwrap()["current"].get<int>();
+        total = result.unwrap()["total"].get<int>();
     } catch (const nlohmann::json::exception& e) {
         co_return Err(Error(Error::JsonDes, e.what()));
     }

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -58,76 +58,224 @@ Task<Result<UserInfoEntity>> NetworkClient::getUserInfo() {
     co_return Ok(entity);
 }
 Task<Result<void>> NetworkClient::refreshAccessToken(std::string const& refreshToken) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::post,
+                                                      endpoint("/refresh-token"),
+                                                      {{"refreshtoken", refreshToken}});
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    UserInfoEntity entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<EventEntityList>> NetworkClient::getActiveEventList() {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/active"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<EventEntityList>> NetworkClient::getLatestEventList() {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/latest"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<EventEntityList>> NetworkClient::getHistoryEventList(int page, int size) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/history",
+                                                               {{"page", page}, {"size", size}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<AttachmentEntity>> NetworkClient::getAttachment(int eventId) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(
+        http::verb::get, endpoint(std::format("api/v2/client/event/{}/attachments", eventId)));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    AttachmentEntity entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<FeedbackEntity>> NetworkClient::getUserFeedback(int eventId) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this
+                      ->request<api::Evento>(http::verb::get,
+                                             endpoint(std::format("/v2/client/event/{}/feedback",
+                                                                  eventId)));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    FeedbackEntity entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<void>> NetworkClient::addUserFeedback(int eventId,
                                                   int rating,
                                                   std::string const& content) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this
+                      ->request<api::Evento>(http::verb::post,
+                                             endpoint(std::format("/v2/client/event/{}/feedback",
+                                                                  eventId),
+                                                      {{"rating", rating}, {"content", content}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+    FeedbackEntity entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<void>> NetworkClient::checkInEvent(int eventId, std::string const& code) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(
+        http::verb::post,
+        endpoint(std::format("/v2/client/event/{}/check-in", eventId), {{"code", code}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    co_return Ok();
 }
 
 Task<Result<void>> NetworkClient::subscribeEvent(int eventId, bool subscribe) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this
+                      ->request<api::Evento>(http::verb::post,
+                                             endpoint(std::format("/v2/client/event/{}/subscribe",
+                                                                  eventId),
+                                                      {{"subscribe", subscribe}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    co_return Ok();
 }
 
 Task<Result<void>> NetworkClient::subscribeDepartment(std::string const& larkDepartment,
                                                       bool subscribe) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this
+                      ->request<api::Evento>(http::verb::post,
+                                             endpoint(std::format("/v2/client/event/{}/subscribe",
+                                                                  larkDepartment),
+                                                      {{"subscribe", subscribe}}));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    co_return Ok();
 }
 
 Task<Result<EventEntityList>> NetworkClient::getParticipatedEvent() {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/participated"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<EventEntityList>> NetworkClient::getSubscribedEvent() {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/subscribed"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    EventEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<SlideEntityList>> NetworkClient::getHomeSlide() {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint("/v2/client/event/slide"));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    SlideEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 Task<Result<SlideEntityList>> NetworkClient::getEventSlide(int eventId) {
-    // TODO: implement me!
-    co_return Error(Error::Unknown);
+    auto result = co_await this->request<api::Evento>(http::verb::get,
+                                                      endpoint(
+                                                          std::format("/v2/client/event/{}/slide",
+                                                                      eventId)));
+    if (result.isErr())
+        co_return Err(result.unwrapErr());
+
+    SlideEntityList entity;
+    try {
+        nlohmann::from_json(result.unwrap(), entity);
+    } catch (const nlohmann::json::exception& e) {
+        co_return Err(Error(Error::JsonDes, e.what()));
+    }
+
+    co_return Ok(entity);
 }
 
 urls::url NetworkClient::endpoint(std::string_view endpoint) {

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -179,7 +179,10 @@ Task<Result<bool>> NetworkClient::checkInEvent(int eventId, std::string const& c
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    co_return Ok(true);
+    if (result.unwrap().is_boolean())
+        co_return Ok(result.unwrap().get<bool>());
+
+    co_return Err(Error(Error::Data, "response data type error"));
 }
 
 Task<Result<bool>> NetworkClient::subscribeEvent(int eventId, bool subscribe) {
@@ -192,7 +195,10 @@ Task<Result<bool>> NetworkClient::subscribeEvent(int eventId, bool subscribe) {
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    co_return Ok(true);
+    if (result.unwrap().is_boolean())
+        co_return Ok(result.unwrap().get<bool>());
+
+    co_return Err(Error(Error::Data, "response data type error"));
 }
 
 Task<Result<bool>> NetworkClient::subscribeDepartment(std::string const& larkDepartment,
@@ -206,7 +212,10 @@ Task<Result<bool>> NetworkClient::subscribeDepartment(std::string const& larkDep
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    co_return Ok(true);
+    if (result.unwrap().is_boolean())
+        co_return Ok(result.unwrap().get<bool>());
+
+    co_return Err(Error(Error::Data, "response data type error"));
 }
 
 Task<Result<EventEntityList>> NetworkClient::getParticipatedEvent() {

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -191,7 +191,7 @@ Task<Result<std::optional<FeedbackEntity>>> NetworkClient::getUserFeedback(int e
     if (result.isErr())
         co_return Err(result.unwrapErr());
 
-    std::optional<FeedbackEntity> entity;
+    std::optional<FeedbackEntity> entity = std::nullopt;
 
     if (result.unwrap().is_null()) {
         co_return Ok(entity);

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -14,6 +14,7 @@
 #include <concepts>
 #include <initializer_list>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 namespace evento {
@@ -49,7 +50,7 @@ public:
 
     Task<Result<EventQueryRes>> getHistoryEventList(int page, int size = 10);
 
-    Task<Result<EventQueryRes>> getDepartmentEventList(std::string const& department,
+    Task<Result<EventQueryRes>> getDepartmentEventList(std::string const& larkDepartment,
                                                        int page,
                                                        int size = 10);
 
@@ -57,7 +58,7 @@ public:
 
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 
-    Task<Result<FeedbackEntity>> getUserFeedback(int eventId);
+    Task<Result<std::optional<FeedbackEntity>>> getUserFeedback(int eventId);
 
     Task<Result<bool>> addUserFeedback(int eventId, int rating, std::string const& content);
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -58,6 +58,8 @@ public:
                                                       int page,
                                                       int size = 10);
 
+    Task<Result<EventEntityList>> getEventList(std::initializer_list<urls::param> params);
+
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 
     Task<Result<FeedbackEntity>> getUserFeedback(int eventId);

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -39,11 +39,25 @@ public:
 
     Task<Result<void>> refreshAccessToken(std::string const& refreshToken);
 
-    Task<Result<EventEntityList>> getActiveEventList();
+    Task<Result<EventEntityList>> getActiveEventList(int& current,
+                                                     int& total,
+                                                     int page,
+                                                     int size = 10);
 
-    Task<Result<EventEntityList>> getLatestEventList();
+    Task<Result<EventEntityList>> getLatestEventList(int& current,
+                                                     int& total,
+                                                     int page,
+                                                     int size = 10);
 
-    Task<Result<EventEntityList>> getHistoryEventList(int page, int size = 10);
+    Task<Result<EventEntityList>> getHistoryEventList(int& current,
+                                                      int& total,
+                                                      int page,
+                                                      int size = 10);
+
+    Task<Result<EventEntityList>> getDepartmentEventList(int& current,
+                                                         int& total,
+                                                         int page,
+                                                         int size = 10);
 
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -28,7 +28,6 @@ using SlideEntityList = std::vector<SlideEntity>;
 using DepartmentInfoEntityList = std::vector<DepartmentInfoEntity>;
 using ContributorList = std::vector<ContributorEntity>;
 
-
 template<typename T>
 using Task = net::awaitable<T>;
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -24,7 +24,6 @@ namespace net = boost::asio;    // from <boost/asio.hpp>
 namespace urls = boost::urls;   // from <boost/url.hpp>
 
 using JsonResult = Result<nlohmann::basic_json<>>;
-using EventEntityList = std::vector<EventEntity>;
 using SlideEntityList = std::vector<SlideEntity>;
 using DepartmentInfoEntityList = std::vector<DepartmentInfoEntity>;
 template<typename T>
@@ -41,34 +40,21 @@ public:
 
     Task<Result<void>> refreshAccessToken(std::string const& refreshToken);
 
-    Task<Result<EventEntityList>> getActiveEventList(int& current,
-                                                     int& total,
-                                                     int page,
-                                                     int size = 10);
+    Task<Result<EventEntityList>> getActiveEventList();
 
-    Task<Result<EventEntityList>> getLatestEventList(int& current,
-                                                     int& total,
-                                                     int page,
-                                                     int size = 10);
+    Task<Result<EventEntityList>> getLatestEventList();
 
-    Task<Result<EventEntityList>> getHistoryEventList(int& current,
-                                                      int& total,
+    Task<Result<EventEntityList>> getHistoryEventList(int page, int size = 10);
+
+    Task<Result<EventEntityList>> getDepartmentEventList(int page, int size = 10);
+
+    Task<Result<EventEntityList>> getActiveEventList(std::string const& Department);
+
+    Task<Result<EventEntityList>> getLatestEventList(std::string const& Department);
+
+    Task<Result<EventEntityList>> getHistoryEventList(std::string const& Department,
                                                       int page,
                                                       int size = 10);
-
-    Task<Result<EventEntityList>> getDepartmentEventList(int& current,
-                                                         int& total,
-                                                         int page,
-                                                         int size = 10);
-
-    Task<Result<EventEntityList>> getActiveEventList(
-        std::string const& Department, int& current, int& total, int page, int size = 10);
-
-    Task<Result<EventEntityList>> getLatestEventList(
-        std::string const& Department, int& current, int& total, int page, int size = 10);
-
-    Task<Result<EventEntityList>> getHistoryEventList(
-        std::string const& Department, int& current, int& total, int page, int size = 10);
 
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -37,7 +37,7 @@ public:
 
     Task<Result<UserInfoEntity>> getUserInfo();
 
-    Task<Result<std::string>> refreshAccessToken(std::string const& refreshToken);
+    Task<Result<void>> refreshAccessToken(std::string const& refreshToken);
 
     Task<Result<EventEntityList>> getActiveEventList();
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -25,7 +25,8 @@ namespace urls = boost::urls;   // from <boost/url.hpp>
 
 using JsonResult = Result<nlohmann::basic_json<>>;
 using SlideEntityList = std::vector<SlideEntity>;
-using DepartmentInfoEntityList = std::vector<DepartmentInfoEntity>;
+using EventEntityList = std::vector<EventEntity>;
+using DepartmentEntityList = std::vector<DepartmentEntity>;
 using ContributorList = std::vector<ContributorEntity>;
 
 template<typename T>
@@ -42,23 +43,17 @@ public:
 
     Task<Result<void>> refreshAccessToken(std::string const& refreshToken);
 
-    Task<Result<EventEntityList>> getActiveEventList();
+    Task<Result<EventQueryRes>> getActiveEventList();
 
-    Task<Result<EventEntityList>> getLatestEventList();
+    Task<Result<EventQueryRes>> getLatestEventList();
 
-    Task<Result<EventEntityList>> getHistoryEventList(int page, int size = 10);
+    Task<Result<EventQueryRes>> getHistoryEventList(int page, int size = 10);
 
-    Task<Result<EventEntityList>> getDepartmentEventList(int page, int size = 10);
+    Task<Result<EventQueryRes>> getDepartmentEventList(std::string const& department,
+                                                       int page,
+                                                       int size = 10);
 
-    Task<Result<EventEntityList>> getActiveEventList(std::string const& Department);
-
-    Task<Result<EventEntityList>> getLatestEventList(std::string const& Department);
-
-    Task<Result<EventEntityList>> getHistoryEventList(std::string const& Department,
-                                                      int page,
-                                                      int size = 10);
-
-    Task<Result<EventEntityList>> getEventList(std::initializer_list<urls::param> params);
+    Task<Result<EventQueryRes>> getEventList(std::initializer_list<urls::param> params);
 
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 
@@ -80,7 +75,7 @@ public:
 
     Task<Result<SlideEntityList>> getEventSlide(int eventId);
 
-    Task<Result<DepartmentInfoEntityList>> getDepartmentInfo();
+    Task<Result<DepartmentEntityList>> getDepartmentList();
 
     Task<Result<ContributorList>> getContributors();
 

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -14,6 +14,7 @@
 #include <concepts>
 #include <initializer_list>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace evento {
 
@@ -25,6 +26,7 @@ namespace urls = boost::urls;   // from <boost/url.hpp>
 using JsonResult = Result<nlohmann::basic_json<>>;
 using EventEntityList = std::vector<EventEntity>;
 using SlideEntityList = std::vector<SlideEntity>;
+using DepartmentInfoEntityList = std::vector<DepartmentInfoEntity>;
 template<typename T>
 using Task = net::awaitable<T>;
 
@@ -59,6 +61,15 @@ public:
                                                          int page,
                                                          int size = 10);
 
+    Task<Result<EventEntityList>> getActiveEventList(
+        std::string const& Department, int& current, int& total, int page, int size = 10);
+
+    Task<Result<EventEntityList>> getLatestEventList(
+        std::string const& Department, int& current, int& total, int page, int size = 10);
+
+    Task<Result<EventEntityList>> getHistoryEventList(
+        std::string const& Department, int& current, int& total, int page, int size = 10);
+
     Task<Result<AttachmentEntity>> getAttachment(int eventId);
 
     Task<Result<FeedbackEntity>> getUserFeedback(int eventId);
@@ -78,6 +89,8 @@ public:
     Task<Result<SlideEntityList>> getHomeSlide();
 
     Task<Result<SlideEntityList>> getEventSlide(int eventId);
+
+    Task<Result<DepartmentInfoEntityList>> getDepartmentInfo();
 
     // access token
     // NOTE: `AUTOMATICALLY` added to request header if exists

--- a/src/Infrastructure/Network/NetworkClient.h
+++ b/src/Infrastructure/Network/NetworkClient.h
@@ -37,7 +37,7 @@ public:
 
     Task<Result<UserInfoEntity>> getUserInfo();
 
-    Task<Result<void>> refreshAccessToken(std::string const& refreshToken);
+    Task<Result<std::string>> refreshAccessToken(std::string const& refreshToken);
 
     Task<Result<EventEntityList>> getActiveEventList();
 
@@ -49,13 +49,13 @@ public:
 
     Task<Result<FeedbackEntity>> getUserFeedback(int eventId);
 
-    Task<Result<void>> addUserFeedback(int eventId, int rating, std::string const& content);
+    Task<Result<bool>> addUserFeedback(int eventId, int rating, std::string const& content);
 
-    Task<Result<void>> checkInEvent(int eventId, std::string const& code);
+    Task<Result<bool>> checkInEvent(int eventId, std::string const& code);
 
-    Task<Result<void>> subscribeEvent(int eventId, bool subscribe);
+    Task<Result<bool>> subscribeEvent(int eventId, bool subscribe);
 
-    Task<Result<void>> subscribeDepartment(std::string const& larkDepartment, bool subscribe);
+    Task<Result<bool>> subscribeDepartment(std::string const& larkDepartment, bool subscribe);
 
     Task<Result<EventEntityList>> getParticipatedEvent();
 

--- a/src/Infrastructure/Network/Response/DepartmentEntity.h
+++ b/src/Infrastructure/Network/Response/DepartmentEntity.h
@@ -6,11 +6,11 @@
 
 namespace evento {
 
-struct DepartmentInfoEntity {
+struct DepartmentEntity {
     std::string id;
     std::string name;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(DepartmentInfoEntity, id, name);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(DepartmentEntity, id, name);
 };
 
 } // namespace evento

--- a/src/Infrastructure/Network/Response/DepartmentInfoEntity.h
+++ b/src/Infrastructure/Network/Response/DepartmentInfoEntity.h
@@ -1,0 +1,16 @@
+// IWYU pragma: private, include <ResponseStruct.h>
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace evento {
+
+struct DepartmentInfoEntity {
+    std::string id;
+    std::string name;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(DepartmentInfoEntity, id, name);
+};
+
+} // namespace evento

--- a/src/Infrastructure/Network/Response/EventEntity.h
+++ b/src/Infrastructure/Network/Response/EventEntity.h
@@ -35,12 +35,4 @@ struct EventEntity {
                                    isCheckedIn);
 };
 
-struct EventQueryRes {
-    std::vector<EventEntity> elements;
-    int current;
-    int total;
-
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventQueryRes, elements, current, total);
-};
-
 } // namespace evento

--- a/src/Infrastructure/Network/Response/EventEntity.h
+++ b/src/Infrastructure/Network/Response/EventEntity.h
@@ -35,12 +35,12 @@ struct EventEntity {
                                    isCheckedIn);
 };
 
-struct EventEntityList {
+struct EventQueryRes {
     std::vector<EventEntity> elements;
     int current;
     int total;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventEntityList, elements, current, total);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventQueryRes, elements, current, total);
 };
 
 } // namespace evento

--- a/src/Infrastructure/Network/Response/EventEntity.h
+++ b/src/Infrastructure/Network/Response/EventEntity.h
@@ -18,7 +18,7 @@ struct EventEntity {
     std::string larkDepartmentName;
     State state;
     bool isSubscribed; // 已订阅
-    bool isChecked;    // 已签到
+    bool isCheckedIn;  // 已签到
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventEntity,
                                    id,
@@ -32,7 +32,15 @@ struct EventEntity {
                                    larkDepartmentName,
                                    state,
                                    isSubscribed,
-                                   isChecked);
+                                   isCheckedIn);
+};
+
+struct EventEntityList {
+    std::vector<EventEntity> elements;
+    int current;
+    int total;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventEntityList, elements, current, total);
 };
 
 } // namespace evento

--- a/src/Infrastructure/Network/Response/EventQueryRes.h
+++ b/src/Infrastructure/Network/Response/EventQueryRes.h
@@ -1,0 +1,17 @@
+// IWYU pragma: private, include <Infrastructure/Network/ResponseStruct.h>
+#pragma once
+
+#include "EventEntity.h"
+#include <nlohmann/json.hpp>
+
+namespace evento {
+
+struct EventQueryRes {
+    std::vector<EventEntity> elements;
+    int current;
+    int total;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(EventQueryRes, elements, current, total);
+};
+
+} // namespace evento

--- a/src/Infrastructure/Network/ResponseStruct.h
+++ b/src/Infrastructure/Network/ResponseStruct.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include "Response/AttachmentEntity.h" // IWYU pragma: export
-#include "Response/EventEntity.h"      // IWYU pragma: export
-#include "Response/FeedbackEntity.h"   // IWYU pragma: export
-#include "Response/LoginResEntity.h"   // IWYU pragma: export
-#include "Response/SlideEntity.h"      // IWYU pragma: export
-#include "Response/UserInfoEntity.h"   // IWYU pragma: export
+#include "Response/AttachmentEntity.h"     // IWYU pragma: export
+#include "Response/DepartmentInfoEntity.h" // IWYU pragma: export
+#include "Response/EventEntity.h"          // IWYU pragma: export
+#include "Response/FeedbackEntity.h"       // IWYU pragma: export
+#include "Response/LoginResEntity.h"       // IWYU pragma: export
+#include "Response/SlideEntity.h"          // IWYU pragma: export
+#include "Response/UserInfoEntity.h"       // IWYU pragma: export

--- a/src/Infrastructure/Network/ResponseStruct.h
+++ b/src/Infrastructure/Network/ResponseStruct.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
-#include "Response/AttachmentEntity.h"     // IWYU pragma: export
-#include "Response/ContributorEntity.h"    // IWYU pragma: export
-#include "Response/DepartmentInfoEntity.h" // IWYU pragma: export
-#include "Response/EventEntity.h"          // IWYU pragma: export
-#include "Response/FeedbackEntity.h"       // IWYU pragma: export
-#include "Response/LoginResEntity.h"       // IWYU pragma: export
-#include "Response/ReleaseEntity.h"        // IWYU pragma: export
-#include "Response/SlideEntity.h"          // IWYU pragma: export
-#include "Response/UserInfoEntity.h"       // IWYU pragma: export
+#include "Response/AttachmentEntity.h"  // IWYU pragma: export
+#include "Response/ContributorEntity.h" // IWYU pragma: export
+#include "Response/DepartmentEntity.h"  // IWYU pragma: export
+#include "Response/EventEntity.h"       // IWYU pragma: export
+#include "Response/FeedbackEntity.h"    // IWYU pragma: export
+#include "Response/LoginResEntity.h"    // IWYU pragma: export
+#include "Response/ReleaseEntity.h"     // IWYU pragma: export
+#include "Response/SlideEntity.h"       // IWYU pragma: export
+#include "Response/UserInfoEntity.h"    // IWYU pragma: export

--- a/src/Infrastructure/Network/ResponseStruct.h
+++ b/src/Infrastructure/Network/ResponseStruct.h
@@ -2,13 +2,12 @@
 
 #pragma once
 
-
 #include "Response/AttachmentEntity.h"     // IWYU pragma: export
-#include "Response/ContributorEntity.h" // IWYU pragma: export
+#include "Response/ContributorEntity.h"    // IWYU pragma: export
 #include "Response/DepartmentInfoEntity.h" // IWYU pragma: export
 #include "Response/EventEntity.h"          // IWYU pragma: export
 #include "Response/FeedbackEntity.h"       // IWYU pragma: export
 #include "Response/LoginResEntity.h"       // IWYU pragma: export
-#include "Response/ReleaseEntity.h"     // IWYU pragma: export
+#include "Response/ReleaseEntity.h"        // IWYU pragma: export
 #include "Response/SlideEntity.h"          // IWYU pragma: export
 #include "Response/UserInfoEntity.h"       // IWYU pragma: export

--- a/src/Infrastructure/Network/ResponseStruct.h
+++ b/src/Infrastructure/Network/ResponseStruct.h
@@ -6,6 +6,7 @@
 #include "Response/ContributorEntity.h" // IWYU pragma: export
 #include "Response/DepartmentEntity.h"  // IWYU pragma: export
 #include "Response/EventEntity.h"       // IWYU pragma: export
+#include "Response/EventQueryRes.h"     // IWYU pragma: export
 #include "Response/FeedbackEntity.h"    // IWYU pragma: export
 #include "Response/LoginResEntity.h"    // IWYU pragma: export
 #include "Response/ReleaseEntity.h"     // IWYU pragma: export


### PR DESCRIPTION
- [x] SAST Link 登录
- [x] 刷新 access token
- [x] 获取用户信息
- [x] 查询活动（新增）
- [x] 获取正在进行的活动
- [x] 获取最新的活动
- [x] 获取历史活动（分页）
- [x] 获取已参加的活动
- [x] 获取已订阅的活动
- [x] 获取指定部门的活动（分页）（新增）
- [x] 获取用户反馈
- [x] 添加反馈
- [x] 签到
- [x] 订阅活动
- [x] 订阅部门
- [x] 获取主页幻灯片
- [x] 获取活动幻灯片
- [x] 获取部门列表（新增）
