### PR TITLE
feat(ui): add page state layer

### DIFF
--- a/ui/components/animation.slint
+++ b/ui/components/animation.slint
@@ -8,7 +8,7 @@
   given easing function require `float(float)` function signature, input 0~1, output 0~1
 */ 
 import { Token } from "../global.slint";
-component LoadingAnimation {
+export component LoadingAnimation {
     // option
     // the time of a repetition
     in property <duration> circle-time: 1000ms;

--- a/ui/components/index.slint
+++ b/ui/components/index.slint
@@ -9,6 +9,10 @@ export {
 } from "./state_layer.slint";
 
 export {
+    PageStateLayer
+} from "./page_state_layer.slint";
+
+export {
     Toast
 } from "./toast.slint";
 
@@ -17,7 +21,8 @@ export {
 } from "./animation.slint";
 
 export {
-    Button
+    Button,
+    ButtonType
 } from "./button.slint";
 
 export {

--- a/ui/components/page_state_layer.slint
+++ b/ui/components/page_state_layer.slint
@@ -1,7 +1,7 @@
 import { Token } from "../global.slint";
 import { LoadingAnimation } from "./animation.slint";
 import { Button } from "./button.slint";
-import { Empty } from "index.slint";
+import { Empty } from "./view_base.slint";
 
 /**
  * this component ALWAYS appears on top of other elements at the same level.

--- a/ui/components/page_state_layer.slint
+++ b/ui/components/page_state_layer.slint
@@ -1,5 +1,7 @@
-import { LoadingAnimation } from "animation.slint";
 import { Token } from "../global.slint";
+import { LoadingAnimation } from "./animation.slint";
+import { Button } from "./button.slint";
+import { Empty } from "index.slint";
 
 /**
  * this component ALWAYS appears on top of other elements at the same level.
@@ -9,10 +11,12 @@ import { Token } from "../global.slint";
  * states:
  * - loading state will show loading animate and a message.
  *      @property is-loading: loading state
+ *      @property loading-message: show as message like "loading ..."
  * 
  * - error state will show a message and a retry button.
  *      @property is-error: error state
  *      @property error-message: show when in error state
+ *      @property error-retry-message: show as retry button content
  *      @callback error-retry: invoke when retry button clicked
  * 
  * state priority (descending):
@@ -23,8 +27,10 @@ export component PageStateLayer {
     // option
     in property <color> background: Token.color.surface;
     in property <bool> is-loading;
+    in property <string> loading-message: "加载中 ...";
     in property <bool> is-error;
-    in property <string> error-message: "Unknown error";
+    in property <string> error-message: "No Content";
+    in property <string> error-retry-message: "Retry";
     callback error-retry();
     // implement
     private property <color> on-surface: Token.color.on-surface;
@@ -47,11 +53,11 @@ export component PageStateLayer {
             LoadingAnimation {
                 width: 24px;
                 height: 24px;
-                stroke: on-surface;
+                color: on-surface;
             }
 
             Text {
-                text: "加载中 ...";
+                text: loading-message;
                 font-size: Token.font.body.large.size;
                 font-weight: Token.font.body.large.weight;
                 color: on-surface;
@@ -62,6 +68,7 @@ export component PageStateLayer {
     private property <bool> show-error-layer;
     if show-error-layer: _error-layer := VerticalLayout {
         alignment: center;
+        spacing: 24px;
         HorizontalLayout {
             alignment: center;
             spacing: 8px;
@@ -80,13 +87,15 @@ export component PageStateLayer {
             }
         }
 
-        // TODO: await button refactor
-        // Button {
-        //     type: ;
-        //     clicked => {
-        //         root.error-retry();
-        //     }
-        // }
+        Empty {
+            Button {
+                type: filled;
+                content: error-retry-message;
+                clicked => {
+                    root.error-retry();
+                }
+            }
+        }
     }
     states [
         error when is-error: {

--- a/ui/components/page_state_layer.slint
+++ b/ui/components/page_state_layer.slint
@@ -3,18 +3,21 @@ import { LoadingAnimation } from "./animation.slint";
 import { Button } from "./button.slint";
 import { Empty } from "./view_base.slint";
 
+export enum PageState{
+    normal,
+    loading,
+    error,
+}
 /**
  * this component ALWAYS appears on top of other elements at the same level.
  * when no state specific, component will invisible.
  * @property background: for hide other visible components
  * 
- * states:
+ * states: (@property state)
  * - loading state will show loading animate and a message.
- *      @property is-loading: loading state
  *      @property loading-message: show as message like "loading ..."
  * 
  * - error state will show a message and a retry button.
- *      @property is-error: error state
  *      @property error-message: show when in error state
  *      @property error-retry-message: show as retry button content
  *      @callback error-retry: invoke when retry button clicked
@@ -25,10 +28,9 @@ import { Empty } from "./view_base.slint";
  */
 export component PageStateLayer {
     // option
+    in property <PageState> state: normal;
     in property <color> background: Token.color.surface;
-    in property <bool> is-loading;
     in property <string> loading-message: "加载中 ...";
-    in property <bool> is-error;
     in property <string> error-message: "No Content";
     in property <string> error-retry-message: "Retry";
     callback error-retry();
@@ -37,10 +39,12 @@ export component PageStateLayer {
     width: 100%;
     height: 100%;
     z: 100;
-    visible: false;
     _background := Rectangle {
         background: background;
     }
+
+    // this touch area is to hide the touch area of invisible elements
+    _area := TouchArea { }
 
     // loading layer
     private property <bool> show-loading-layer;
@@ -98,24 +102,34 @@ export component PageStateLayer {
         }
     }
     states [
-        error when is-error: {
+        error when state == PageState.error: {
             visible: true;
             show-error-layer: true;
         }
-        loading when is-loading: {
+        loading when state == PageState.loading: {
             visible: true;
             show-loading-layer: true;
+        }
+        normal when true: {
+            visible: false;
         }
     ]
 }
 
 component Test {
     PageStateLayer {
-        is-loading: true;
-        // is-error: true;
+        state: error;
+        error-retry => {
+            debug("retry")
+        }
     }
 
     Rectangle {
-        background: red;
+        background: black;
+        Button {
+            clicked => {
+                debug("123123")
+            }
+        }
     }
 }

--- a/ui/components/page_state_layer.slint
+++ b/ui/components/page_state_layer.slint
@@ -1,0 +1,112 @@
+import { LoadingAnimation } from "animation.slint";
+import { Token } from "../global.slint";
+
+/**
+ * this component ALWAYS appears on top of other elements at the same level.
+ * when no state specific, component will invisible.
+ * @property background: for hide other visible components
+ * 
+ * states:
+ * - loading state will show loading animate and a message.
+ *      @property is-loading: loading state
+ * 
+ * - error state will show a message and a retry button.
+ *      @property is-error: error state
+ *      @property error-message: show when in error state
+ *      @callback error-retry: invoke when retry button clicked
+ * 
+ * state priority (descending):
+ * - error
+ * - loading
+ */
+export component PageStateLayer {
+    // option
+    in property <color> background: Token.color.surface;
+    in property <bool> is-loading;
+    in property <bool> is-error;
+    in property <string> error-message: "Unknown error";
+    callback error-retry();
+    // implement
+    private property <color> on-surface: Token.color.on-surface;
+    width: 100%;
+    height: 100%;
+    z: 100;
+    visible: false;
+    _background := Rectangle {
+        background: background;
+    }
+
+    // loading layer
+    private property <bool> show-loading-layer;
+    if show-loading-layer: _loading-layer := VerticalLayout {
+        alignment: center;
+        HorizontalLayout {
+            height: self.preferred-height;
+            alignment: center;
+            spacing: 8px;
+            LoadingAnimation {
+                width: 24px;
+                height: 24px;
+                stroke: on-surface;
+            }
+
+            Text {
+                text: "加载中 ...";
+                font-size: Token.font.body.large.size;
+                font-weight: Token.font.body.large.weight;
+                color: on-surface;
+            }
+        }
+    }
+    // error layer
+    private property <bool> show-error-layer;
+    if show-error-layer: _error-layer := VerticalLayout {
+        alignment: center;
+        HorizontalLayout {
+            alignment: center;
+            spacing: 8px;
+            Image {
+                width: 24px;
+                height: 24px;
+                source: Token.image.icon.error;
+                colorize: Token.color.error;
+            }
+
+            Text {
+                text: error-message;
+                font-size: Token.font.body.large.size;
+                font-weight: Token.font.body.large.weight;
+                color: Token.color.error;
+            }
+        }
+
+        // TODO: await button refactor
+        // Button {
+        //     type: ;
+        //     clicked => {
+        //         root.error-retry();
+        //     }
+        // }
+    }
+    states [
+        error when is-error: {
+            visible: true;
+            show-error-layer: true;
+        }
+        loading when is-loading: {
+            visible: true;
+            show-loading-layer: true;
+        }
+    ]
+}
+
+component Test {
+    PageStateLayer {
+        is-loading: true;
+        // is-error: true;
+    }
+
+    Rectangle {
+        background: red;
+    }
+}


### PR DESCRIPTION
决定将页面状态添加为可选的组件，提供最大灵活性。具体使用方法见代码注释。close #40
发现没有好用的按钮，等待重构按钮。

组件提供了如下状态：

- Normal
- Loading
- Error

Tasks:

- [x] 添加基础内容
- [x] 测试，移除冗余代码，导出组件