### PR TITLE
feat(ui)!: add md3 button

### DIFF
--- a/ui/assets/image/image_token.slint
+++ b/ui/assets/image/image_token.slint
@@ -1,5 +1,5 @@
 import { Palette, Button } from "std-widgets.slint";
-import { EventoStyleToken } from "../../logic/index.slint";
+import { MdStyleToken } from "../../logic/md_style_token.slint";
 
 struct ImgPair {
     light: image,
@@ -54,7 +54,7 @@ export global EventoImageToken {
         display: display,
     };
     pure function switcher(img: ImgPair) -> image {
-        return EventoStyleToken.is-darkmode ? img.dark : img.light;
+        return MdStyleToken.is-darkmode ? img.dark : img.light;
     }
     //
     // icon used as small image in button, navbar and so on

--- a/ui/components/animation.slint
+++ b/ui/components/animation.slint
@@ -8,65 +8,78 @@
   given easing function require `float(float)` function signature, input 0~1, output 0~1
 */ 
 import { Token } from "../global.slint";
-component LoadingAnimation inherits Path {
-    // available option
+component LoadingAnimation {
+    // option
     // the time of a repetition
     in property <duration> circle-time: 1000ms;
     // the min distance between head and tail (percentage of a circle)
     in property <float> distance: 0.1;
-    // width
-    stroke-width: 3px;
-    // color
-    stroke: Token.color.on-primary-container;
-    // implement detail
-    viewbox-height: 1;
-    viewbox-width: 1;
-    private property <float> radius: 0.5;
-    // 0~1, means the progress of a repetition
-    private property <float> progress: Math.mod(animation-tick() / 1ms,circle-time / 1ms) / (circle-time / 1ms);
-    private property <float> tail: easing(progress, distance) - distance / 2;
-    private property <float> head: easing(progress, - distance) + distance / 2;
-    private property <{x: float, y: float}> tail-point: polar-to-cartesian(radius, tail * 1turn);
-    private property <{x: float, y: float}> head-point: polar-to-cartesian(radius, head * 1turn);
-    MoveTo {
-        x: tail-point.x;
-        y: tail-point.y;
-    }
-
-    ArcTo {
-        sweep: true;
-        large-arc: head - tail > 0.5;
-        radius-x: radius;
-        radius-y: radius;
-        x: head-point.x;
-        y: head-point.y;
-    }
-
-    pure function easing(x: float, offset: float) -> float {
-        if (offset > 0) {
-            return x > offset ? _inner-easing((x - offset) / (1 - offset)) : 0;
-        } else if (offset < 0) {
-            return x < 1 + offset ? _inner-easing(x / (1 + offset)) : 1;
-        } else {
-            return _inner-easing(x);
+    in property <length> line-width: 3px;
+    in property <color> color: Token.color.on-primary-container;
+    in property <bool> disable;
+    // implement
+    width: 100%;
+    height: 100%;
+    Path {
+        x: 0;
+        y: 0;
+        width <=> parent.width;
+        height <=> parent.height;
+        stroke-width: line-width;
+        stroke: color;
+        viewbox-height: 1;
+        viewbox-width: 1;
+        private property <float> radius: 0.5;
+        // 0~1, means the progress of a repetition
+        private property <duration> start-time;
+        init => {
+            start-time = animation-tick();
         }
-    }
-    // convenient easing change
-    pure function _inner-easing(x: float) -> float {
-        return ease-in-out-quint(x);
-    }
-    // easing function from https://easings.net/
-    pure function ease-in-out-sine(x: float) -> float {
-        return -(Math.cos(3.1415926 * x * 1rad) - 1) / 2;
-    }
-    pure function ease-in-out-quint(x: float) -> float {
-        return x < 0.5 ? 16 * x * x * x * x * x : 1 - Math.pow(-2 * x + 2, 5) / 2;
-    }
-    // polar to cartesian coordinate system
-    pure function polar-to-cartesian(r: float, theta: angle) -> {x: float, y: float} {
-        return {
-            x: 0.5 + r * Math.cos(theta - 90deg),
-            y: 0.5 + r * Math.sin(theta - 90deg),
-        };
+        private property <float> progress: disable ? 0 : Math.mod((animation-tick() - start-time) / 1ms,circle-time / 1ms) / (circle-time / 1ms);
+        private property <float> tail: easing(progress, distance) - distance / 2;
+        private property <float> head: easing(progress, - distance) + distance / 2;
+        private property <{x: float, y: float}> tail-point: polar-to-cartesian(radius, tail * 1turn);
+        private property <{x: float, y: float}> head-point: polar-to-cartesian(radius, head * 1turn);
+        MoveTo {
+            x: tail-point.x;
+            y: tail-point.y;
+        }
+
+        ArcTo {
+            sweep: true;
+            large-arc: head - tail > 0.5;
+            radius-x: radius;
+            radius-y: radius;
+            x: head-point.x;
+            y: head-point.y;
+        }
+
+        pure function easing(x: float, offset: float) -> float {
+            if (offset > 0) {
+                return x > offset ? _inner-easing((x - offset) / (1 - offset)) : 0;
+            } else if (offset < 0) {
+                return x < 1 + offset ? _inner-easing(x / (1 + offset)) : 1;
+            } else {
+                return _inner-easing(x);
+            }
+        }
+        // convenient easing change
+        pure function _inner-easing(x: float) -> float {
+            return ease-in-out-quint(x);
+        }
+        // easing function from https://easings.net/
+        pure function ease-in-out-sine(x: float) -> float {
+            return -(Math.cos(3.1415926 * x * 1rad) - 1) / 2;
+        }
+        pure function ease-in-out-quint(x: float) -> float {
+            return x < 0.5 ? 16 * x * x * x * x * x : 1 - Math.pow(-2 * x + 2, 5) / 2;
+        }
+        // polar to cartesian coordinate system
+        pure function polar-to-cartesian(r: float, theta: angle) -> {x: float, y: float} {
+            return {
+                x: 0.5 + r * Math.cos(theta - 90deg),
+                y: 0.5 + r * Math.sin(theta - 90deg),
+            };
+        }
     }
 }

--- a/ui/components/button.slint
+++ b/ui/components/button.slint
@@ -1,83 +1,271 @@
 import { StateLayer } from "state_layer.slint";
-import { Token } from "../global.slint";
+import { Token, MdElevationData, MdFontData } from "../global.slint";
 import { LoadingAnimation } from "animation.slint";
+import { Empty } from "view_base.slint";
 
-export component LoadingButton inherits Rectangle {
-    // available option
-    in property <color> on-surface: Token.color.on-surface;
-    in property <color> surface: Token.color.surface-container;
-    in property <bool> is-loading: false;
+export enum ButtonType{
+    elevated,
+    filled,
+    filled-tonal,
+    outlined,
+    text,
+}
+/**
+ * a general button matching MD3 common button requirement.
+ * ref: https://m3.material.io/components/buttons/overview
+ * 
+ * support general item as icon, max size: 18px*18px, just add as a child element.
+ * 
+ * types:
+ * - elevated
+ * - filled
+ * - filled-tonal
+ * - outlined
+ * - text
+ */
+export component Button {
+    callback clicked <=> _area.clicked;
+    // option
+    in property <ButtonType> type: text;
+    in property <bool> disable;
     in property <string> content: "No Content";
-    in property <length> font-size: Token.font.body.large.size;
-    height: 40px;
-    callback clicked <=> area.clicked;
-    // implement detail
+    in property <bool> have-icon: false;
+    in property <color> elevated-surface: Token.color.surface-container-low;
+    in property <color> elevated-on-surface: Token.color.primary;
+    in property <color> filled-surface: Token.color.primary;
+    in property <color> filled-on-surface: Token.color.on-primary;
+    in property <color> filled-tonal-surface: Token.color.secondary-container;
+    in property <color> filled-tonal-on-surface: Token.color.on-secondary-container;
+    in property <color> outlined-on-surface: Token.color.primary;
+    in property <color> outlined-outline: Token.color.outline;
+    in property <color> text-on-surface: Token.color.primary;
+    // out
+    out property <color> surface;
+    out property <color> on-surface;
+    out property <color> outline;
+    out property <MdElevationData> elevation: Token.elevation.level0;
+    // implement
+    private property <color> disable-color: Token.color.on-surface;
+    private property <MdFontData> font: Token.font.body.large;
     private property <length> max-radius: 20px;
     private property <length> icon-size: 18px;
     private property <length> default-padding: 24px;
     private property <length> icon-padding: 16px;
     private property <length> default-spacing: 8px;
-    clip: true;
-    background: surface;
-    border-radius: self.height / 2 > max-radius ? max-radius : self.height / 2;
-    StateLayer {
-        background: on-surface;
-        is-hover: area.has-hover;
-        is-press: area.pressed;
-    }
-
-    _spinner := LoadingAnimation {
-        x: icon-padding;
-        width: icon-size;
-        stroke: on-surface;
-    }
-
-    _text := Text {
-        x: (root.width - self.width) / 2;
-        text: content;
-        font-size: font-size;
-        vertical-alignment: center;
-        horizontal-alignment: center;
-    }
-
-    area := TouchArea {
-        mouse-cursor: pointer;
-    }
-
-    states [
-        // width = icon-padding + icon-size + default-spacing + _text.width + default-padding
-        loading when is-loading: {
-            width: icon-padding + icon-size + default-spacing + _text.width + default-padding;
-            _text.x: icon-padding + icon-size + default-spacing;
-            _spinner.opacity: 1;
-            in {
-                animate width, _text.x, _spinner.opacity {
-                    duration: 200ms;
-                    easing: ease-in-out-quint;
-                }
-            }
-            out {
-                animate width, _text.x, _spinner.opacity {
-                    duration: 200ms;
-                    easing: ease-in-out-quint;
-                }
-            }
+    min-height: 40px;
+    min-width: _body.min-width;
+    preferred-height: 40px;
+    preferred-width: _body.preferred-width;
+    // max-height: 40px;
+    // max-width: _body.max-width;
+    vertical-stretch: 0;
+    horizontal-stretch: 0;
+    _body := Rectangle {
+        x: 0;
+        y: 0;
+        height <=> parent.height;
+        width <=> parent.width;
+        background: surface;
+        border-color: outline;
+        border-radius: self.height / 2 > max-radius ? max-radius : self.height / 2;
+        drop-shadow-color: Token.color.shadow;
+        drop-shadow-offset-y: elevation.offset-y;
+        drop-shadow-blur: elevation.blur;
+        clip: true;
+        StateLayer {
+            color: on-surface;
+            disable: root.disable;
+            is-hover: _area.has-hover;
+            is-press: _area.pressed;
         }
-        // width = default-padding + _text.width + default-padding
-        normal when !is-loading: {
-            width: default-padding + _text.width + default-padding;
-            _text.x: default-padding;
-            _spinner.opacity: 0;
+
+        _body-layout := HorizontalLayout {
+            alignment: center;
+            padding-left: default-padding;
+            padding-right: default-padding;
+            spacing: 0;
+            _icon-bound := Empty {
+                height: 100%;
+                opacity: 0;
+                _icon := Rectangle {
+                    height: icon-size;
+                    width: icon-size;
+                    clip: true;
+                    @children
+                }
+            }
+
+            Empty {
+                height: 100%;
+                _text := Text {
+                    text: content;
+                    font-size: font.size;
+                    font-weight: font.weight;
+                    color: on-surface;
+                    vertical-alignment: center;
+                }
+            }
+
+            states [
+                have-icon when have-icon: {
+                    spacing: default-spacing;
+                    padding-left: icon-padding;
+                    _icon-bound.opacity: 1;
+                    _icon-bound.width: icon-size;
+                    in {
+                        animate spacing, padding-left, _icon-bound.opacity, _icon-bound.width {
+                            duration: 200ms;
+                            easing: ease-in-out-quint;
+                        }
+                    }
+                    out {
+                        animate spacing, padding-left, _icon-bound.opacity, _icon-bound.width {
+                            duration: 200ms;
+                            easing: ease-in-out-quint;
+                        }
+                    }
+                }
+            ]
+        }
+
+        _area := TouchArea {
+            mouse-cursor: disable ? default : pointer;
+        }
+
+        animate drop-shadow-offset-y, drop-shadow-blur {
+            duration: 200ms;
+            easing: ease-in-out-quint;
+        }
+    }
+
+    animate surface, on-surface, outline {
+        duration: 200ms;
+        easing: ease-in-out-quint;
+    }
+    states [
+        elevated-disable when disable && type == ButtonType.elevated: {
+            surface: disable-color.with-alpha(0.12);
+            on-surface: disable-color.with-alpha(0.38);
+            elevation: Token.elevation.level0;
+            _body.drop-shadow-color: #00000000;
+        }
+        elevated when type == ButtonType.elevated: {
+            surface: elevated-surface;
+            on-surface: elevated-on-surface;
+            elevation: Token.elevation.level1;
+        }
+        filled-disable when disable && type == ButtonType.filled: {
+            surface: disable-color.with-alpha(0.12);
+            on-surface: disable-color.with-alpha(0.38);
+        }
+        filled when type == ButtonType.filled: {
+            surface: filled-surface;
+            on-surface: filled-on-surface;
+        }
+        filled-tonal-disable when disable && type == ButtonType.filled-tonal: {
+            surface: disable-color.with-alpha(0.12);
+            on-surface: disable-color.with-alpha(0.38);
+        }
+        filled-tonal when type == ButtonType.filled-tonal: {
+            surface: filled-tonal-surface;
+            on-surface: filled-tonal-on-surface;
+        }
+        outlined-disable when disable && type == ButtonType.outlined: {
+            surface: transparent;
+            on-surface: disable-color.with-alpha(0.38);
+            outline: outlined-outline.with-alpha(0.12);
+            _body.border-width: 1px;
+        }
+        outlined when type == ButtonType.outlined: {
+            surface: transparent;
+            on-surface: outlined-on-surface;
+            outline: outlined-outline;
+            _body.border-width: 1px;
+        }
+        text-disable when disable && type == ButtonType.text: {
+            surface: transparent;
+            on-surface: disable-color.with-alpha(0.38);
+        }
+        text when type == ButtonType.text: {
+            surface: transparent;
+            on-surface: text-on-surface;
         }
     ]
 }
 
 // quick preview
 component Example {
-    LoadingButton {
-        content: "click me";
-        clicked => {
-            self.is-loading = !self.is-loading;
+    property <bool> disable;
+    property <bool> icon;
+    VerticalLayout {
+        // alignment: start;
+        // width: 500px;
+        HorizontalLayout {
+            Button {
+                content: "disable";
+                type: ButtonType.elevated;
+                clicked => {
+                    root.disable = !root.disable;
+                }
+            }
+
+            Button {
+                content: "icon";
+                type: ButtonType.elevated;
+                clicked => {
+                    root.icon = !root.icon;
+                }
+            }
+        }
+
+        Button {
+            have-icon: icon;
+            type: ButtonType.elevated;
+            disable: root.disable;
+            LoadingAnimation {
+                disable: parent.disable;
+                color: parent.on-surface;
+            }
+        }
+
+        Button {
+            have-icon: icon;
+            type: ButtonType.filled;
+            disable: root.disable;
+            LoadingAnimation {
+                color: parent.on-surface;
+                disable: parent.disable;
+            }
+        }
+
+        Button {
+            have-icon: icon;
+            type: ButtonType.filled-tonal;
+            disable: root.disable;
+            LoadingAnimation {
+                disable: parent.disable;
+                color: parent.on-surface;
+            }
+        }
+
+        Button {
+            have-icon: icon;
+            type: ButtonType.outlined;
+            disable: root.disable;
+            LoadingAnimation {
+                disable: parent.disable;
+                color: parent.on-surface;
+            }
+        }
+
+        Button {
+            have-icon: icon;
+            type: ButtonType.text;
+            disable: root.disable;
+            LoadingAnimation {
+                disable: parent.disable;
+                color: parent.on-surface;
+            }
         }
     }
 }

--- a/ui/components/index.slint
+++ b/ui/components/index.slint
@@ -17,7 +17,7 @@ export {
 } from "./animation.slint";
 
 export {
-    LoadingButton
+    Button
 } from "./button.slint";
 
 export {

--- a/ui/components/state_layer.slint
+++ b/ui/components/state_layer.slint
@@ -1,24 +1,52 @@
-export component StateLayer inherits Rectangle {
+export component StateLayer {
+    // option
+    in property <color> color: #00000000;
+    in property <color> background: #00000000;
     in property <bool> is-hover: false;
     in property <bool> is-focus: false;
     in property <bool> is-press: false;
     in property <bool> is-drag: false;
-    pure function get-opacity() -> float {
-        if is-drag {
-            return 0.16;
-        } else if is-press {
-            return 0.1;
-        } else if is-focus {
-            return 0.1;
-        } else if is-hover {
-            return 0.08;
-        } else {
-            return 0;
+    in property <bool> disable;
+    // implement
+    height: 100%;
+    width: 100%;
+    _body := Rectangle {
+        background: color == rgba(0,0,0,0) ? background : color;
+        opacity: 0;
+        animate opacity {
+            duration: 100ms;
+            easing: linear;
         }
     }
-    opacity: get-opacity();
-    animate opacity {
-        duration: 100ms;
-        easing: linear;
+
+    states [
+        disable when disable: {
+            _body.opacity: 0;
+        }
+        drag when is-drag: {
+            _body.opacity: 0.16;
+        }
+        press when is-press: {
+            _body.opacity: 0.1;
+        }
+        focus when is-focus: {
+            _body.opacity: 0.1;
+        }
+        hover when is-hover: {
+            _body.opacity: 0.08;
+        }
+    ]
+}
+
+component Test {
+    StateLayer {
+        width: 100%;
+        height: 100%;
+        background: red;
+        is-hover: area.has-hover;
+        is-press: area.pressed;
+        // disable: true;
     }
+
+    area := TouchArea { }
 }

--- a/ui/global.slint
+++ b/ui/global.slint
@@ -1,15 +1,21 @@
 import { EventoImageToken } from "./assets/index.slint";
-import { EventoStyleToken } from "./logic/index.slint";
+import { MdStyleToken } from "./logic/md_style_token.slint";
 
 import { Palette } from "std-widgets.slint";
 import { Themes } from "./modules/surrealism-ui/use/index.slint";
 
+export { 
+    MdFontData,
+    MdElevationData,
+} from "./logic/md_style_token.slint";
+
 export global Token {
-    out property is-darkmode <=> EventoStyleToken.is-darkmode;
+    out property is-darkmode <=> MdStyleToken.is-darkmode;
     out property <Themes> surrealism-ui-default-theme: is-darkmode ? Dark : Light;
     out property image <=> EventoImageToken.image;
-    out property font <=> EventoStyleToken.font;
-    out property color <=> EventoStyleToken.color;
+    out property font <=> MdStyleToken.font;
+    out property color <=> MdStyleToken.color;
+    out property elevation <=> MdStyleToken.elevation;
     public function set-display-mode(color-scheme: ColorScheme) {
         Palette.color-scheme = color-scheme;
     }

--- a/ui/logic/index.slint
+++ b/ui/logic/index.slint
@@ -1,14 +1,15 @@
-export { EventoStyleToken } from "./style_token.slint";
-export { 
+export {
     ViewManager,
     ViewManagerBridge,
     ViewName,
 } from "./view_manager.slint";
-export { 
+
+export {
     AccountManager,
     AccountManagerBridge,
 } from "./account_manager.slint";
-export { 
+
+export {
     MessageManager,
     MessageManagerBridge,
     MessageType,

--- a/ui/logic/md_style_token.slint
+++ b/ui/logic/md_style_token.slint
@@ -1,32 +1,42 @@
 import { Palette, Button } from "std-widgets.slint";
+export { 
+    MdFontData,
+    MdElevationData,
+}
 
 // font
-struct EventoFontData {
+struct MdFontData {
     size: length,
     weight: int,
 }
 
-struct EventoFontSize {
-    large: EventoFontData,
-    medium: EventoFontData,
-    small: EventoFontData,
+struct MdFontTypeData {
+    large: MdFontData,
+    medium: MdFontData,
+    small: MdFontData,
 }
 
 // five types: large, headline, title, body, label
 // more info: https://m3.material.io/styles/typography/applying-type#ab657e7c-cb93-45ff-92c6-686959dc19ae
-struct EventoFontCollection {
-    display: EventoFontSize,
-    headline: EventoFontSize,
-    title: EventoFontSize,
-    body: EventoFontSize,
-    label: EventoFontSize,
+struct MdFontStruct {
+    display: MdFontTypeData,
+    headline: MdFontTypeData,
+    title: MdFontTypeData,
+    body: MdFontTypeData,
+    label: MdFontTypeData,
 }
 
 // color
 // more info: https://m3.material.io/styles/color/roles
-struct EventoColorCollection {
+struct MdColorStruct {
+    primary: color,
+    on-primary: color,
     primary-container: color,
     on-primary-container: color,
+    secondary: color,
+    on-secondary: color,
+    secondary-container: color,
+    on-secondary-container: color,
     surface: color,
     on-surface: color,
     surface-variant: color,
@@ -42,12 +52,34 @@ struct EventoColorCollection {
     outline-variant: color,
     error: color,
     on-error: color,
+    scrim: color,
+    shadow: color,
 }
 
-export global EventoStyleToken {
-    out property <EventoColorCollection> color:{
+struct MdElevationData {
+    offset-y: length,
+    blur: length,
+}
+
+struct MdElevationStruct {
+    level0: MdElevationData,
+    level1: MdElevationData,
+    level2: MdElevationData,
+    level3: MdElevationData,
+    level4: MdElevationData,
+    level5: MdElevationData,
+}
+
+export global MdStyleToken {
+    out property <MdColorStruct> color:{
+        primary: switcher({ light: #6750A4, dark: #D0BCFF }),
+        on-primary: switcher({ light: #FFFFFF, dark: #381E72 }),
         primary-container: switcher({ light: #EADDFF, dark: #4F378B }),
         on-primary-container: switcher({ light: #4F378B, dark: #EADDFF }),
+        secondary: switcher({ light: #625B71, dark: #CCC2DC }),
+        on-secondary: switcher({ light: #FFFFFF, dark: #332D41 }),
+        secondary-container: switcher({ light: #E8DEF8, dark: #4A4458 }),
+        on-secondary-container: switcher({ light: #4A4458, dark: #E8DEF8 }),
         surface: switcher({ light: #FEF7FF, dark: #141218 }),
         on-surface: switcher({ light:#1D1B20, dark:  #E6E0E9 }),
         surface-variant: switcher({ light: #E7E0EC, dark: #49454F }),
@@ -63,10 +95,12 @@ export global EventoStyleToken {
         outline-variant: switcher({ light: #CAC4D0, dark: #49454F }),
         error: switcher({ light: #B3261E, dark: #F2B8B5 }),
         on-error: switcher({ light: #FFFFFF, dark: #601410 }),
+        scrim: #000000,
+        shadow: #000000,
     };
     // source: https://m3.material.io/styles/typography/type-scale-tokens#a734c6ed-634c-4abb-adb2-35daf0aed06a
     // prefer large, use body.large (16px) for body text
-    out property <EventoFontCollection> font:{
+    out property <MdFontStruct> font:{
         display: {
             large: {
                 size: 57px,
@@ -138,8 +172,51 @@ export global EventoStyleToken {
             }
         },
     };
+    out property <MdElevationStruct> elevation:{
+        level0: {
+            offset-y: 0px,
+            blur: 0px,
+        },
+        level1: {
+            offset-y: 1px,
+            blur: 2px,
+        },
+        level2: {
+            offset-y: 3px,
+            blur: 4px,
+        },
+        level3: {
+            offset-y: 6px,
+            blur: 7px,
+        },
+        level4: {
+            offset-y: 8px,
+            blur: 9px,
+        },
+        level5: {
+            offset-y: 12px,
+            blur: 13px,
+        },
+    };
     out property <bool> is-darkmode: Palette.color-scheme == ColorScheme.dark;
     pure function switcher(color: {light:color,dark:color}) -> color {
         return self.is-darkmode ? color.dark : color.light;
     }
 }
+
+// component ElevationTest {
+//     Rectangle {
+//         background: white;
+//     }
+
+//     Rectangle {
+//         private property <MdElevationData> level: MdStyleToken.elevation.level1;
+//         background: white;
+//         height: 50px;
+//         width: 50px;
+//         drop-shadow-offset-y: level.offset-y;
+//         drop-shadow-blur: level.blur;
+//         drop-shadow-color: black;
+//         border-radius: 20px;
+//     }
+// }

--- a/ui/views/overlay/menu.slint
+++ b/ui/views/overlay/menu.slint
@@ -80,28 +80,28 @@ component Avatar inherits Rectangle {
 export component MenuOverlay inherits Overlay {
     states [
         is-show when MenuOverlayBridge.is-show: {
-            shadow.background: Colors.rgba(0,0,0,0.5);
+            shadow.opacity: 0.32;
             content.x: root.width - content.width;
             in {
-                animate content.x, shadow.background {
+                animate content.x, shadow.opacity {
                     duration: 400ms;
                     easing: ease-out-quart;
                 }
             }
             out {
-                animate content.x, shadow.background {
+                animate content.x, shadow.opacity {
                     duration: 200ms;
                     easing: ease-in-quart;
                 }
             }
         }
         not-show when !MenuOverlayBridge.is-show: {
-            shadow.background: Colors.rgba(0,0,0,0);
+            shadow.opacity: 0;
             content.x: root.width;
         }
     ]
     shadow := Rectangle {
-        background: transparent;
+        background: Token.color.scrim;
         shadow-area := TouchArea {
             clicked => {
                 MenuOverlayBridge.is-show = false;

--- a/ui/views/overlay/menu.slint
+++ b/ui/views/overlay/menu.slint
@@ -1,7 +1,6 @@
 import { Overlay, Empty, StateLayer } from "../../components/index.slint";
 import { ViewManager, ViewName, AccountManager, MessageType, MessageManager } from "../../logic/index.slint";
 import { Token } from "../../global.slint";
-import { SAvatar } from "../../modules/surrealism-ui/src/avatar/index.slint";
 import { ROOT-STYLES } from "../../modules/surrealism-ui/themes/index.slint";
 
 export global MenuOverlayBridge {


### PR DESCRIPTION
添加了 MD3 文档中的 [common button](https://m3.material.io/components/buttons/specs) 的支持，5 种按钮完全可用。

![example](https://github.com/user-attachments/assets/26973697-a636-4c4b-bb5a-8c9d9bee439d)

支持：
- 自定义颜色
- 禁用状态
- 插入icon，或任何希望作为icon的元素（最大18px * 18px）

默认 fit-content，详细选项请看代码。

当希望插入icon时，只需：

```
Button {
    have-icon: icon;
    type: ButtonType.text;
    disable: root.disable;
    LoadingAnimation {
        disable: parent.disable;
        color: parent.on-surface;
    }
}
```

其他内容：

- `StateLayer` 添加新参数 `color`，原 `background` 仍然可用

BREAKING CHANGE: 目前 `LoadingButton` 已被删除，请使用 `LoadingAnimation` 和 `Button` 的组合