### PR TITLE
feat(network): improve error message readability

### DIFF
--- a/src/Infrastructure/Network/HttpsAccessManager.cc
+++ b/src/Infrastructure/Network/HttpsAccessManager.cc
@@ -38,7 +38,14 @@ Task<ResponseResult> HttpsAccessManager::makeReply(std::string host,
     beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(30));
 
     // Make the connection on the IP address we get from a lookup
-    co_await beast::get_lowest_layer(stream).async_connect(results);
+    try {
+        co_await beast::get_lowest_layer(stream).async_connect(results);
+    } catch (const boost::system::system_error& e) {
+        if (e.code() == net::error::timed_out) {
+            co_return Err(Error(Error::Timeout, "Connection timed out"));
+        }
+        co_return Err(Error(Error::Network, e.what()));
+    }
 
     // Set the timeout.
     beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(30));
@@ -56,7 +63,14 @@ Task<ResponseResult> HttpsAccessManager::makeReply(std::string host,
     beast::get_lowest_layer(stream).expires_after(_timeout);
 
     // Send the HTTP request to the remote host
-    co_await http::async_write(stream, req);
+    try {
+        co_await http::async_write(stream, req);
+    } catch (const boost::system::system_error& e) {
+        if (e.code() == net::error::timed_out) {
+            co_return Err(Error(Error::Timeout, "Write operation timed out"));
+        }
+        co_return Err(Error(Error::Network, e.what()));
+    }
 
     // Declare a container to hold the response
     http::response<http::dynamic_body> res;
@@ -64,8 +78,14 @@ Task<ResponseResult> HttpsAccessManager::makeReply(std::string host,
     beast::flat_buffer buffer;
 
     // Receive the HTTP response
-    co_await http::async_read(stream, buffer, res);
-
+    try {
+        co_await http::async_read(stream, buffer, res);
+    } catch (const boost::system::system_error& e) {
+        if (e.code() == net::error::timed_out) {
+            co_return Err(Error(Error::Timeout, "Read operation timed out"));
+        }
+        co_return Err(Error(Error::Network, e.what()));
+    }
     beast::get_lowest_layer(stream).expires_after(_timeout);
 
     // Gracefully close the stream - do not threat every error as an exception!

--- a/src/Infrastructure/Network/HttpsAccessManager.cc
+++ b/src/Infrastructure/Network/HttpsAccessManager.cc
@@ -1,5 +1,6 @@
 #include "HttpsAccessManager.h"
 #include <Infrastructure/Utils/Debug.h>
+#include <Infrastructure/Utils/Error.h>
 #include <Infrastructure/Utils/Result.h>
 #include <boost/asio/as_tuple.hpp>
 #include <boost/asio/awaitable.hpp>

--- a/src/Infrastructure/Network/NetworkClient.cc
+++ b/src/Infrastructure/Network/NetworkClient.cc
@@ -564,7 +564,7 @@ urls::url NetworkClient::githubEndpoint(std::string_view endpoint,
 
 JsonResult NetworkClient::handleResponse(http::response<http::dynamic_body> response) {
     if (response.result() != http::status::ok) {
-        return Err(Error(Error::Network, std::to_string(response.result_int())));
+        return Err(Error(response.result_int()));
     }
 
     nlohmann::basic_json<> res;

--- a/src/Infrastructure/Utils/Error.h
+++ b/src/Infrastructure/Utils/Error.h
@@ -1,7 +1,7 @@
 // IWYU pragma: private, include <Infrastructure/Utils/Result.h>
 #pragma once
-
 #include <string>
+#include <unordered_map>
 namespace evento {
 
 class Error {
@@ -29,11 +29,22 @@ public:
 private:
     std::string _reason;
 
-    inline static std::string _reasonMap[Unknown + 1] = {"SSL error!",
+    inline static std::string _reasonMap[Unknown + 2] = {"SSL error!",
                                                          "Network error!",
                                                          "Json Deserialization error!",
                                                          "Data error",
+                                                         "Timeout error!",
                                                          "Unknown Error"};
-};
+    inline static std::unordered_map<int, std::string> _errorCodeMap = {{100, "Continue"},
+                                                                        {200, "OK"},
+                                                                        {400, "Bad Request"},
+                                                                        {401, "Unauthorized"},
+                                                                        {403, "Forbidden"},
+                                                                        {404, "Not Found"},
+                                                                        {500,
+                                                                         "Internal Server Error"},
+                                                                        {502, "Bad Gateway"},
+                                                                        {503,
+                                                                         "Service Unavailable"}};
 
 } // namespace evento

--- a/src/Infrastructure/Utils/Error.h
+++ b/src/Infrastructure/Utils/Error.h
@@ -1,18 +1,14 @@
 // IWYU pragma: private, include <Infrastructure/Utils/Result.h>
 #pragma once
+
 #include <string>
 #include <unordered_map>
+
 namespace evento {
 
 class Error {
 public:
-    enum Kind {
-        Ssl = 0,
-        Network,
-        JsonDes,
-        Data,
-        Unknown,
-    } kind;
+    enum Kind { Ssl = 0, Network, JsonDes, Data, Unknown, Timeout } kind;
 
     Error(Kind kind, std::string_view reason)
         : kind(kind)
@@ -22,6 +18,10 @@ public:
         : kind(kind)
         , _reason(_reasonMap[kind]) {}
 
+    Error(int code)
+        : kind(Unknown)
+        , _reason(_errorCodeMap.at(code)) {}
+
     [[nodiscard]] std::string what() const { return _reason; }
 
     operator std::string() const { return what(); }
@@ -29,22 +29,24 @@ public:
 private:
     std::string _reason;
 
-    inline static std::string _reasonMap[Unknown + 2] = {"SSL error!",
+    inline static std::string _reasonMap[Timeout + 1] = {"SSL error!",
                                                          "Network error!",
                                                          "Json Deserialization error!",
                                                          "Data error",
-                                                         "Timeout error!",
-                                                         "Unknown Error"};
-    inline static std::unordered_map<int, std::string> _errorCodeMap = {{100, "Continue"},
-                                                                        {200, "OK"},
-                                                                        {400, "Bad Request"},
-                                                                        {401, "Unauthorized"},
-                                                                        {403, "Forbidden"},
-                                                                        {404, "Not Found"},
-                                                                        {500,
-                                                                         "Internal Server Error"},
-                                                                        {502, "Bad Gateway"},
-                                                                        {503,
-                                                                         "Service Unavailable"}};
+                                                         "Unknown Error",
+                                                         "Timeout error!"};
+
+    inline static std::unordered_map<int, std::string> _errorCodeMap = {
+        {100, "Continue"},
+        {200, "OK"},
+        {400, "Bad Request"},
+        {401, "Unauthorized"},
+        {403, "Forbidden"},
+        {404, "Not Found"},
+        {500, "Internal Server Error"},
+        {502, "Bad Gateway"},
+        {503, "Service Unavailable"},
+    };
+};
 
 } // namespace evento

--- a/src/Infrastructure/Utils/Error.h
+++ b/src/Infrastructure/Utils/Error.h
@@ -8,7 +8,14 @@ namespace evento {
 
 class Error {
 public:
-    enum Kind { Ssl = 0, Network, JsonDes, Data, Unknown, Timeout } kind;
+    enum Kind {
+        Ssl = 0,
+        Network,
+        JsonDes,
+        Data,
+        Unknown,
+        Timeout,
+    } kind;
 
     Error(Kind kind, std::string_view reason)
         : kind(kind)
@@ -18,9 +25,14 @@ public:
         : kind(kind)
         , _reason(_reasonMap[kind]) {}
 
-    Error(int code)
-        : kind(Unknown)
-        , _reason(_errorCodeMap.at(code)) {}
+    Error(unsigned int httpStatusCode)
+        : kind(Unknown) {
+        if (_httpStatusCodeMap.contains(httpStatusCode)) {
+            _reason = _httpStatusCodeMap[httpStatusCode];
+        } else {
+            _reason = _reasonMap[Kind::Network];
+        }
+    }
 
     [[nodiscard]] std::string what() const { return _reason; }
 
@@ -36,16 +48,14 @@ private:
                                                          "Unknown Error",
                                                          "Timeout error!"};
 
-    inline static std::unordered_map<int, std::string> _errorCodeMap = {
-        {100, "Continue"},
-        {200, "OK"},
-        {400, "Bad Request"},
-        {401, "Unauthorized"},
-        {403, "Forbidden"},
-        {404, "Not Found"},
-        {500, "Internal Server Error"},
-        {502, "Bad Gateway"},
-        {503, "Service Unavailable"},
+    inline static std::unordered_map<unsigned, std::string> _httpStatusCodeMap = {
+        {400u, "400 Bad Request"},
+        {401u, "401 Unauthorized"},
+        {403u, "403 Forbidden"},
+        {404u, "404 Not Found"},
+        {500u, "500 Internal Server Error"},
+        {502u, "502 Bad Gateway"},
+        {503u, "503 Service Unavailable"},
     };
 };
 


### PR DESCRIPTION
errorinfo reflection

whats new:


try-catch added to:
async_connect
async_write
async_read

unordered_map<int, std::string> _errorCodeMap{101~503}

Error(int code)
        : kind(Unknown)
        , _reason(_errorCodeMap.at(code)) {}