### PR TITLE
fix: remove Version field in desktop file

### DIFF
--- a/deploy/create-deb.sh
+++ b/deploy/create-deb.sh
@@ -41,7 +41,6 @@ mkdir -p "$TMP_DIR/usr/share/applications"
 cat > "$TMP_DIR/usr/share/applications/sast-evento.desktop" << EOF
 [Desktop Entry]
 Name=SAST Evento
-Version=$VERSION
 Comment=An event management system developed and used by NJUPT SAST
 Exec=sast-evento
 Icon=sast-evento

--- a/deploy/pacman/PKGBUILD
+++ b/deploy/pacman/PKGBUILD
@@ -12,7 +12,6 @@ depends=(qt6-base)
 provides=(sast-evento)
 conflicts=(sast-evento)
 package() {
-  eventover=$(cat "${srcdir}/sast-evento-version.txt")
   mkdir -p "${pkgdir}/opt/sast-evento"
   bsdtar --numeric-owner --group=0 --owner=0 -xzf "${srcdir}/files.tar.gz" -C "${pkgdir}/opt/sast-evento"
   install -D -m644 "${srcdir}/icon.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/sast-evento.svg"
@@ -20,7 +19,6 @@ package() {
   cat > "${pkgdir}/usr/share/applications/sast-evento.desktop" << EOF
 [Desktop Entry]
 Name=SAST Evento
-Version=${eventover}
 Comment=An event management system developed and used by NJUPT SAST
 Exec=sast-evento
 Icon=sast-evento


### PR DESCRIPTION
根据 [文档](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html)，Version 字段用于存储所遵循的 Desktop Entry Specification 版本号（可省略），而非程序版本号