### PR TITLE
fix: downgrade qt into `>=6.2.0` for pre-built Linux binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       uses: jurplel/install-qt-action@v4
       if: matrix.qt_arch
       with:
-        version: '6.6.3'
+        version: '6.2.0'
         arch: ${{ matrix.qt_arch }}
         cache: true
 


### PR DESCRIPTION
Ubuntu 22.04 正在使用 6.2，而 Ubuntu 24.04 正在使用 6.4

Qt ABI 理论上向下兼容，在 6.2 下编译的版本可以在 6.7/6.8 的环境中正常运行