### PR TITLE
chore: update upstream fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ emerge -av eselect-repository
 eselect repository add corcodile git https://github.com/f3rmata/corcodile.git
 ```
 
-Using `spdlog` in overlay to fix the bundled `fmt` issue.
 ```bash
-emerge -av spdlog::corcodile sast-evento
+emerge -av app-misc/sast-evento --autounmask
 ```
 
 ## :open_file_folder: Files Produced

--- a/doc/README_zh.md
+++ b/doc/README_zh.md
@@ -82,9 +82,8 @@ emerge -av eselect-repository
 eselect repository add corcodile git https://github.com/f3rmata/corcodile.git
 ```
 
-使用 overlay 中的 `spdlog` 解决捆绑的 `fmt` 问题。
 ```bash
-emerge -av spdlog::corcodile sast-evento
+emerge -av app-misc/sast-evento --autounmask
 ```
 
 ## :open_file_folder: 生成的文件


### PR DESCRIPTION
更新 Gentoo 上游 `spdlog` 的修复，不再使用源内的版本。